### PR TITLE
Use HTTP instead of HTTPS in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ via an interactive shell / terminal.
 ![VideoGif](https://raw.githubusercontent.com/iopipe/lambda-shell/master/contrib/demo.gif)
 
 Requirements:
- - Apex (https://apex.run)
+ - Apex (http://apex.run)
  - Amazon AWS account
 
 # Installation


### PR DESCRIPTION
Hello. I can't find `https://apex.run`, it uses probably HTTP.

Thank you.

![](https://cloud.githubusercontent.com/assets/5249050/21968068/de8fdd58-dbd3-11e6-8f6b-7f4a1e6e5891.png)
